### PR TITLE
fix: exception handling for fusion auth http requests

### DIFF
--- a/src/admin/admin.service.ts
+++ b/src/admin/admin.service.ts
@@ -1,10 +1,12 @@
 import { User } from '@fusionauth/typescript-client';
 import { HttpService } from '@nestjs/axios';
-import { Injectable } from '@nestjs/common';
+import { HttpException, HttpStatus, Injectable } from '@nestjs/common';
 import { ResponseCode, ResponseStatus, UsersResponse } from './admin.interface';
 import { FusionauthService } from './fusionauth/fusionauth.service';
 import { v4 as uuidv4 } from 'uuid';
-import { catchError, map } from 'rxjs';
+import { catchError, map, throwError } from 'rxjs';
+import { resolve } from 'path';
+import { rejects } from 'assert';
 
 @Injectable()
 export class AdminService {
@@ -63,8 +65,8 @@ export class AdminService {
             'Content-Type': 'application/json'
         }}).pipe(
         map(response => response.status===200?{msg: "Password changed successfully"}:{msg:"Password cannot be changed"}),
-        catchError(e=>{
-          return e.data;
+        catchError(e=> {
+          throw new HttpException({error: e.response.data}, HttpStatus.BAD_REQUEST);
         })
         );
     }
@@ -76,8 +78,8 @@ export class AdminService {
             'Content-Type': 'application/json'
         }}).pipe(
         map(response => response.data),
-        catchError(e=>{
-          return e.data;
+        catchError(e=> {
+          throw new HttpException({error: e.response.data}, HttpStatus.BAD_REQUEST);
         })
         );
     }
@@ -89,8 +91,8 @@ export class AdminService {
             'Content-Type': 'application/json'
         }}).pipe(
         map(response => response.data),
-        catchError(e=>{
-          return e.data;
+        catchError(e=> {
+          throw new HttpException({error: e.response.data}, HttpStatus.BAD_REQUEST);
         })
         );
     }


### PR DESCRIPTION
<!-- Please refer to CONTRIBUTING.md (https://github.com/Samagra-Development/uci-pwa/blob/main/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

Exception Handling for http req within service

### Changes

* Added Exception Handling for inter service http req within the module **for Admin rotes**

## How to test

### Sample Request:
```
curl --location --request POST '{{host-url}}/admin/createUser' \
--header 'Authorization: Bearer  {{admin_token}}' \
--header 'Content-Type: application/json' \
--data-raw '{
        "registration": {
            "applicationId": "f0ddb3f6-091b-45e4-8c0f-889f89d4f5da",
            "preferredLanguages": ["en"],
            "roles": ["Teacher"],
            "timezone": "Asia/Kolkata",
            "username": "him1212p",
            "usernameStatus": "ACTIVE"
        },
        "user": {
            "firstName":"test",
            "data":{
                "udise": "2010100102",
                "school": 2
            },
            "email":"hekk@gmail.com",
            "preferredLanguages": ["en"],
            "timezone": "Asia/Kolkata",
            "usernameStatus": "ACTIVE",
            "username": "him12121p",
                            "mobilePhone": "8219781037",
            "password": "himachalb21345"
        }
    }'
```

### Expected response:
```
{
    "error": {
        "fieldErrors": {
            "user.email": [
                {
                    "code": "[duplicate]user.email",
                    "message": "A User with email [hekk@gmail.com] already exists."
                }
            ]
        }
    }
}
```
Please consider using the closing keyword if the pull request is proposed to
fix an issue already created in the repository
(https://help.github.com/articles/closing-issues-using-keywords/)